### PR TITLE
Fix incorrect list.json format

### DIFF
--- a/list.json
+++ b/list.json
@@ -14,5 +14,5 @@ layout: null
             {%- if forloop.last == false -%},{%- endif -%}
         {%- endfor %}
 
-    }
+    ]
 }


### PR DESCRIPTION
Currently, it generates incorrect list.json. It generates it like this:
```js
{
    "bundles": [
        // ...
    } // the array ends with a curly brace instead of a square bracket
}
```
This PR fixes the issue.